### PR TITLE
Fix ast parsing on Python 3.6 and 3.7

### DIFF
--- a/delvewheel/wheel_repair.py
+++ b/delvewheel/wheel_repair.py
@@ -196,8 +196,8 @@ class WheelRepair:
         else:
             # insert patch after docstring
             if len(children) == 0 or not isinstance(children[0], ast.Expr) or \
-                    not isinstance(children[0].value, ast.Constant) or \
-                    children[0].value.value != docstring:
+                    not isinstance(children[0].value, ast.Str) or \
+                    children[0].value.s != docstring:
                 raise ValueError('Error parsing __init__.py: docstring exists but is not the first element of the parse tree')
             elif len(children) == 1:
                 with open(init_path, 'a') as file:


### PR DESCRIPTION
This fixes issue #10, at least on my side, and seems to work on Python 3.6, 3.7 and 3.8. 

I am not sure if there are situations in which the `docstring` will not be interpreted as an `ast.Str`, so perhaps this is not the best solution.