### PR TITLE
Restore CONDA_DLL_SEARCH_MODIFICATION_ENABLE once used

### DIFF
--- a/delvewheel/wheel_repair.py
+++ b/delvewheel/wheel_repair.py
@@ -37,8 +37,18 @@ def _delvewheel_init_patch_{0}():
     libs_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, {1!r}))
     if sys.version_info[:2] >= (3, 8):
         if os.path.exists(os.path.join(sys.base_prefix, 'conda-meta')):
+            # backup the state of the environment variable CONDA_DLL_SEARCH_MODIFICATION_ENABLE
+            conda_dll_search_modification_enable = os.environ.get("CONDA_DLL_SEARCH_MODIFICATION_ENABLE")
             os.environ['CONDA_DLL_SEARCH_MODIFICATION_ENABLE']='1'
+
         os.add_dll_directory(libs_dir)
+
+        if os.path.exists(os.path.join(sys.base_prefix, 'conda-meta')):
+            # restore the state of the environment variable CONDA_DLL_SEARCH_MODIFICATION_ENABLE
+            if conda_dll_search_modification_enable is None:
+                os.environ.pop("CONDA_DLL_SEARCH_MODIFICATION_ENABLE", None)
+            else:
+                os.environ["CONDA_DLL_SEARCH_MODIFICATION_ENABLE"] = conda_dll_search_modification_enable
     else:
         from ctypes import WinDLL
         with open(os.path.join(libs_dir, {2!r})) as file:


### PR DESCRIPTION
Hello,

the fix for #14 may have a bad side effect with some other packages (at least with xlwings from pypi) on windows with anaconda, because the environment variable `CONDA_DLL_SEARCH_MODIFICATION_ENABLE` is left defined when it should not.


