### PR TITLE
Always use windows-style newlines in .load-order files

### DIFF
--- a/delvewheel/_wheel_repair.py
+++ b/delvewheel/_wheel_repair.py
@@ -676,7 +676,7 @@ class WheelRepair:
             load_order_filepath = os.path.join(libs_dir, load_order_filename)
             if os.path.exists(load_order_filepath):
                 raise FileExistsError(f'{os.path.relpath(load_order_filepath, self._extract_dir)} already exists')
-            with open(os.path.join(libs_dir, load_order_filename), 'w') as file:
+            with open(os.path.join(libs_dir, load_order_filename), 'w', newline='\r\n') as file:
                 file.write('\n'.join(reversed(rev_dll_load_order)))
                 file.write('\n')
         else:


### PR DESCRIPTION
I'm using `delvewheel` as part of https://github.com/jvolkman/repairwheel. One of my goals is bit-for-bit reproducibility of repaired wheels regardless of the host platform.

With this change, the `.load-order` file uses the same windows-style line endings even if it's generated on linux or macos.