### PR TITLE
🩹 fix free-threading support

### DIFF
--- a/delvewheel/_dll_list.py
+++ b/delvewheel/_dll_list.py
@@ -38,7 +38,7 @@ class MachineType(enum.Enum):
 
 # set of regular expressions for additional DLLs to ignore
 ignore_regexes = {
-    re.compile(r'python[0-9]+(_d)?\.dll'),  # included in CPython distribution
+    re.compile(r'python[0-9]+t?(_d)?\.dll'),  # included in CPython distribution
     re.compile(r'libpypy([0-9]+\.)*[0-9]+-c\.dll'),  # included in PyPy distribution
     re.compile('api-.*'),  # let Windows handle API sets
 }


### PR DESCRIPTION
This tiny PR adds free-threaded python to `ignore_regexes`.
Without this fix, delvewheel would not ignore `python313t.dll` and would patch it in the wheel which, subsequently, leads to access violations when trying to import the repaired wheel.

Given that I am not too familiar with the delvewheel codebase, I am not sure if there are other places where this needs to be fixed. At least a local test run with a free-threading build confirmed this to be working.