### PR TITLE
Fixes for PyArrow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,8 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install ../dist/delvewheel-*.whl
-          python run_tests.py -v LinuxTestCase
+          pip install setuptools
+          python run_tests.py -v
       - name: deploy
         if: env.VERSION_CHANGED == '1' && github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'adang1345'
         working-directory: ${{ github.workspace }}

--- a/delvewheel/_dll_utils.py
+++ b/delvewheel/_dll_utils.py
@@ -445,7 +445,7 @@ def get_all_needed(lib_path: str,
                                     vc_redist_linker_version = f'{vc_redist_linker_version[0]}.{vc_redist_linker_version[1]}'
                                     warnings.warn(f'{os.path.basename(lib_path)} was built with a newer platform toolset ({linker_version}) than the discovered {os.path.basename(dll_info[0])} ({vc_redist_linker_version}). This may cause compatibility issues.')
                         elif on_error == 'raise':
-                            raise FileNotFoundError(f'Unable to find library: {dll_name}')
+                            raise FileNotFoundError(f'Unable to find library: {dll_name}; {lib_arch=}, {wheel_dirs=}')
                         else:
                             not_found.add(dll_name)
                     else:


### PR DESCRIPTION
Assorted fixes and improvements:

* ensure the entire test suite passes under Linux
* add `--no-patch` option to disable the DLL search path patching logic
* add `--mangle-only` option to select individual DLL to name-mangle
* dependencies already in the wheel are not copied into `<distname>.libs` anymore
